### PR TITLE
Lesson 5. Добавлены тесты получения списка питомцев по валидном и невалидным статусам.

### DIFF
--- a/tests/test_pet.py
+++ b/tests/test_pet.py
@@ -2,6 +2,7 @@
 
 import allure
 import jsonschema
+import pytest
 import requests
 from .schemas.pet_schema import PET_SCHEMA
 
@@ -158,3 +159,36 @@ class TestPet:
             response = requests.get(f"{BASE_URL}/pet/{pet_id}")
         with allure.step("Проверка статуса ответа и данных питомца"):
             assert response.status_code == 404
+
+    @allure.title("Проверка получения списка питомцев по валидному статусу")
+    @pytest.mark.parametrize(
+        "status, expected_status_code",
+        [
+            ("available", 200),
+            ("pending", 200),
+            ("sold", 200)
+        ]
+    )
+    def test_get_pets_by_valid_status_(self, status, expected_status_code):
+        with allure.step(f"Отправка запроса на получение питомцев по статусу {status}"):
+            response = requests.get(f"{BASE_URL}/pet/findByStatus", params={"status": status})
+
+        with allure.step("Проверка статуса ответа и формата данных"):
+            assert response.status_code == expected_status_code
+            assert isinstance(response.json(), list)
+
+    @allure.title("Проверка получения списка питомцев по невалидному статусу")
+    @pytest.mark.parametrize(
+        "status, expected_status_code",
+        [
+            ("", 400),
+            ("nonexistent", 400)
+        ]
+    )
+    def test_get_pets_by_invalid_status_(self, status, expected_status_code):
+        with allure.step(f"Отправка запроса на получение питомцев по статусу {status}"):
+            response = requests.get(f"{BASE_URL}/pet/findByStatus", params={"status": status})
+
+        with allure.step("Проверка статуса ответа и формата данных"):
+            assert response.status_code == expected_status_code
+            assert isinstance(response.json(), dict)


### PR DESCRIPTION
Повторно создал ветку, не смог решить конфликты после слития изменений с 4 урока в ветку main.
Исправил замечания:
1. Разделил проверки по валидным и невалидным статусам на 2 отдельных теста;
2. Исправил проверку типа данных в ответе для случая с невалидным статусом.

Прогон тестов: http://5.181.109.28:8080/job/VAPetShopApiTests/8/allure/